### PR TITLE
symbol->png will also accept fpng as a stream

### DIFF
--- a/image/png.lisp
+++ b/image/png.lisp
@@ -27,7 +27,10 @@ pixels on all four sides"
                     (set-color qrarray x y 255)))
               ;; quiet zone
               (set-color qrarray x y 255))))
-      (zpng:write-png qrpng fpng :if-exists :supersede))))
+              ;; is fpng a pathname/string or a stream?
+              (typecase fpng
+                 ((or pathname string) (zpng:write-png qrpng fpng :if-exists :supersede))
+                 (stream (zpng:write-png-stream qrpng fpng))))))
 
 (defun encode-png (text &key (fpath "qrcode.png") (version 1) (level :level-m)
                    (mode nil) (pixsize 9) (margin 8))


### PR DESCRIPTION
thanks for that nice lib! I needed a qr-code dynamically created for use with hunchentoot - so I needed to write the png-image to a stream, changes attached.

example - serve a dynamic qr-code with hunchentoot:

(ql:quickload :hunchentoot)
(hunchentoot:start (make-instance 'hunchentoot:easy-acceptor :port 8080))
(hunchentoot:define-easy-handler (teste :uri "/test")
    ()
  (setf (hunchentoot:content-type*) "image/png")
  (let ((out (hunchentoot:send-headers)))
    (cl-qrencode:encode-png "my qr-code" :fpath out)))

point your browser to http://localhost:8080/test
