### PR TITLE
Fix padding and verify one particular sample.

### DIFF
--- a/qrencode/codeword.lisp
+++ b/qrencode/codeword.lisp
@@ -6,7 +6,7 @@
 
 (defun padding-bits (bstream)
   "add padding bits so that BSTREAM ends at a codeword boundary"
-  (make-list (- 8 (mod (length bstream) 8)) :initial-element 0))
+  (make-list (- (nth-value 1 (ceiling (length bstream) 8))) :initial-element 0))
 
 (defun pad-codewords (bstream version level)
   "add pad codewords (after adding padding-bits) to fill data codeword capacity"

--- a/test/encode-test.lisp
+++ b/test/encode-test.lisp
@@ -38,3 +38,16 @@
       (cl-qrencode::data-masking input)
     (declare (ignore masked))
     (assert-equal '(0 1 0) mask-ref)))
+
+(defun hex-string-to-bytes (string)
+  (with-input-from-string (stream string)
+    (loop with *read-base* = 16 for x = (read stream NIL) while x collect x)))
+
+(define-test validate-encoding
+  (let ((expected (hex-string-to-bytes "40 86 86 57 27 06 46 57   27 00 ec 11 ec 11 ec 11"))
+        (generated (cl-qrencode::bytes->input
+                    (cl-qrencode::ascii->bytes
+                     "herpderp")
+                    1 :level-m NIL)))
+    (assert-equal expected (cl-qrencode::bstream->codewords
+                            (slot-value generated 'cl-qrencode::bstream)))))


### PR DESCRIPTION
This fixes the padding if the length is already a multiple of eight (i.e. it doesn't add padding in that case instead of adding another eight bits).

Also adds another test sample to ensure one particular sample that still fails after decoding - just to make sure it's still correct at this stage.